### PR TITLE
fix prod deploy: использовать ~/admin_prod и docker compose

### DIFF
--- a/.github/workflows/deploy_prod.yaml
+++ b/.github/workflows/deploy_prod.yaml
@@ -20,12 +20,9 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            cd ~/frontend_admin_prod
+            cd ~/admin_prod
             git pull
-            rm -rf dist
-            docker build . --output type=local,dest=./dist
-            rm -rf /var/www/admin_prod/*
-            cp -r ./dist/* /var/www/admin_prod
+            docker compose up --force-recreate -d --no-deps --build admin-frontend
 
       - name: Send success message
         if: ${{ success() }}


### PR DESCRIPTION
Workflow ожидал ~/frontend_admin_prod и сборку через docker build --output → /var/www/admin_prod, но реальная инфраструктура использует ~/admin_prod + docker-compose с контейнером admin-frontend на порту 4173, который проксируется nginx.